### PR TITLE
[ENG-19324] chore: change json_args to empty interface

### DIFF
--- a/edgefunctions/api/openapi.yaml
+++ b/edgefunctions/api/openapi.yaml
@@ -393,9 +393,7 @@ components:
           type: string
         code:
           type: string
-        json_args:
-          properties: {}
-          type: object
+        json_args: {}
         function_to_run:
           type: string
         initiator_type:
@@ -473,9 +471,7 @@ components:
           type: string
         code:
           type: string
-        json_args:
-          properties: {}
-          type: object
+        json_args: {}
         active:
           type: boolean
         initiator_type:
@@ -534,9 +530,7 @@ components:
           type: string
         code:
           type: string
-        json_args:
-          properties: {}
-          type: object
+        json_args: {}
         active:
           type: boolean
         initiator_type:
@@ -555,9 +549,7 @@ components:
           type: string
         code:
           type: string
-        json_args:
-          properties: {}
-          type: object
+        json_args: {}
         active:
           type: boolean
       type: object

--- a/edgefunctions/docs/CreateEdgeFunctionRequest.md
+++ b/edgefunctions/docs/CreateEdgeFunctionRequest.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **Language** | Pointer to **string** |  | [optional] 
 **Code** | Pointer to **string** |  | [optional] 
-**JsonArgs** | Pointer to **map[string]interface{}** |  | [optional] 
+**JsonArgs** | Pointer to **interface{}** |  | [optional] 
 **Active** | Pointer to **bool** |  | [optional] 
 **InitiatorType** | Pointer to **string** |  | [optional] 
 
@@ -107,20 +107,20 @@ HasCode returns a boolean if a field has been set.
 
 ### GetJsonArgs
 
-`func (o *CreateEdgeFunctionRequest) GetJsonArgs() map[string]interface{}`
+`func (o *CreateEdgeFunctionRequest) GetJsonArgs() interface{}`
 
 GetJsonArgs returns the JsonArgs field if non-nil, zero value otherwise.
 
 ### GetJsonArgsOk
 
-`func (o *CreateEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool)`
+`func (o *CreateEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool)`
 
 GetJsonArgsOk returns a tuple with the JsonArgs field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetJsonArgs
 
-`func (o *CreateEdgeFunctionRequest) SetJsonArgs(v map[string]interface{})`
+`func (o *CreateEdgeFunctionRequest) SetJsonArgs(v interface{})`
 
 SetJsonArgs sets JsonArgs field to given value.
 
@@ -130,6 +130,16 @@ SetJsonArgs sets JsonArgs field to given value.
 
 HasJsonArgs returns a boolean if a field has been set.
 
+### SetJsonArgsNil
+
+`func (o *CreateEdgeFunctionRequest) SetJsonArgsNil(b bool)`
+
+ SetJsonArgsNil sets the value for JsonArgs to be an explicit nil
+
+### UnsetJsonArgs
+`func (o *CreateEdgeFunctionRequest) UnsetJsonArgs()`
+
+UnsetJsonArgs ensures that no value is present for JsonArgs, not even an explicit nil
 ### GetActive
 
 `func (o *CreateEdgeFunctionRequest) GetActive() bool`

--- a/edgefunctions/docs/PatchEdgeFunctionRequest.md
+++ b/edgefunctions/docs/PatchEdgeFunctionRequest.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **string** |  | [optional] 
 **Code** | Pointer to **string** |  | [optional] 
-**JsonArgs** | Pointer to **map[string]interface{}** |  | [optional] 
+**JsonArgs** | Pointer to **interface{}** |  | [optional] 
 **Active** | Pointer to **bool** |  | [optional] 
 
 ## Methods
@@ -80,20 +80,20 @@ HasCode returns a boolean if a field has been set.
 
 ### GetJsonArgs
 
-`func (o *PatchEdgeFunctionRequest) GetJsonArgs() map[string]interface{}`
+`func (o *PatchEdgeFunctionRequest) GetJsonArgs() interface{}`
 
 GetJsonArgs returns the JsonArgs field if non-nil, zero value otherwise.
 
 ### GetJsonArgsOk
 
-`func (o *PatchEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool)`
+`func (o *PatchEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool)`
 
 GetJsonArgsOk returns a tuple with the JsonArgs field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetJsonArgs
 
-`func (o *PatchEdgeFunctionRequest) SetJsonArgs(v map[string]interface{})`
+`func (o *PatchEdgeFunctionRequest) SetJsonArgs(v interface{})`
 
 SetJsonArgs sets JsonArgs field to given value.
 
@@ -103,6 +103,16 @@ SetJsonArgs sets JsonArgs field to given value.
 
 HasJsonArgs returns a boolean if a field has been set.
 
+### SetJsonArgsNil
+
+`func (o *PatchEdgeFunctionRequest) SetJsonArgsNil(b bool)`
+
+ SetJsonArgsNil sets the value for JsonArgs to be an explicit nil
+
+### UnsetJsonArgs
+`func (o *PatchEdgeFunctionRequest) UnsetJsonArgs()`
+
+UnsetJsonArgs ensures that no value is present for JsonArgs, not even an explicit nil
 ### GetActive
 
 `func (o *PatchEdgeFunctionRequest) GetActive() bool`

--- a/edgefunctions/docs/PutEdgeFunctionRequest.md
+++ b/edgefunctions/docs/PutEdgeFunctionRequest.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **string** |  | [optional] 
 **Code** | Pointer to **string** |  | [optional] 
-**JsonArgs** | Pointer to **map[string]interface{}** |  | [optional] 
+**JsonArgs** | Pointer to **interface{}** |  | [optional] 
 **Active** | Pointer to **bool** |  | [optional] 
 **InitiatorType** | Pointer to **string** |  | [optional] 
 **Language** | Pointer to **string** |  | [optional] 
@@ -82,20 +82,20 @@ HasCode returns a boolean if a field has been set.
 
 ### GetJsonArgs
 
-`func (o *PutEdgeFunctionRequest) GetJsonArgs() map[string]interface{}`
+`func (o *PutEdgeFunctionRequest) GetJsonArgs() interface{}`
 
 GetJsonArgs returns the JsonArgs field if non-nil, zero value otherwise.
 
 ### GetJsonArgsOk
 
-`func (o *PutEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool)`
+`func (o *PutEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool)`
 
 GetJsonArgsOk returns a tuple with the JsonArgs field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetJsonArgs
 
-`func (o *PutEdgeFunctionRequest) SetJsonArgs(v map[string]interface{})`
+`func (o *PutEdgeFunctionRequest) SetJsonArgs(v interface{})`
 
 SetJsonArgs sets JsonArgs field to given value.
 
@@ -105,6 +105,16 @@ SetJsonArgs sets JsonArgs field to given value.
 
 HasJsonArgs returns a boolean if a field has been set.
 
+### SetJsonArgsNil
+
+`func (o *PutEdgeFunctionRequest) SetJsonArgsNil(b bool)`
+
+ SetJsonArgsNil sets the value for JsonArgs to be an explicit nil
+
+### UnsetJsonArgs
+`func (o *PutEdgeFunctionRequest) UnsetJsonArgs()`
+
+UnsetJsonArgs ensures that no value is present for JsonArgs, not even an explicit nil
 ### GetActive
 
 `func (o *PutEdgeFunctionRequest) GetActive() bool`

--- a/edgefunctions/docs/Results.md
+++ b/edgefunctions/docs/Results.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **Language** | Pointer to **string** |  | [optional] 
 **Code** | Pointer to **string** |  | [optional] 
-**JsonArgs** | Pointer to **map[string]interface{}** |  | [optional] 
+**JsonArgs** | Pointer to **interface{}** |  | [optional] 
 **FunctionToRun** | Pointer to **string** |  | [optional] 
 **InitiatorType** | Pointer to **string** |  | [optional] 
 **Active** | Pointer to **bool** |  | [optional] 
@@ -137,20 +137,20 @@ HasCode returns a boolean if a field has been set.
 
 ### GetJsonArgs
 
-`func (o *Results) GetJsonArgs() map[string]interface{}`
+`func (o *Results) GetJsonArgs() interface{}`
 
 GetJsonArgs returns the JsonArgs field if non-nil, zero value otherwise.
 
 ### GetJsonArgsOk
 
-`func (o *Results) GetJsonArgsOk() (*map[string]interface{}, bool)`
+`func (o *Results) GetJsonArgsOk() (*interface{}, bool)`
 
 GetJsonArgsOk returns a tuple with the JsonArgs field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetJsonArgs
 
-`func (o *Results) SetJsonArgs(v map[string]interface{})`
+`func (o *Results) SetJsonArgs(v interface{})`
 
 SetJsonArgs sets JsonArgs field to given value.
 
@@ -160,6 +160,16 @@ SetJsonArgs sets JsonArgs field to given value.
 
 HasJsonArgs returns a boolean if a field has been set.
 
+### SetJsonArgsNil
+
+`func (o *Results) SetJsonArgsNil(b bool)`
+
+ SetJsonArgsNil sets the value for JsonArgs to be an explicit nil
+
+### UnsetJsonArgs
+`func (o *Results) UnsetJsonArgs()`
+
+UnsetJsonArgs ensures that no value is present for JsonArgs, not even an explicit nil
 ### GetFunctionToRun
 
 `func (o *Results) GetFunctionToRun() string`

--- a/edgefunctions/model_create_edge_function_request.go
+++ b/edgefunctions/model_create_edge_function_request.go
@@ -19,7 +19,7 @@ type CreateEdgeFunctionRequest struct {
 	Name *string `json:"name,omitempty"`
 	Language *string `json:"language,omitempty"`
 	Code *string `json:"code,omitempty"`
-	JsonArgs *map[string]interface{} `json:"json_args,omitempty"`
+	JsonArgs interface{} `json:"json_args,omitempty"`
 	Active *bool `json:"active,omitempty"`
 	InitiatorType *string `json:"initiator_type,omitempty"`
 }
@@ -137,22 +137,23 @@ func (o *CreateEdgeFunctionRequest) SetCode(v string) {
 	o.Code = &v
 }
 
-// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise.
-func (o *CreateEdgeFunctionRequest) GetJsonArgs() map[string]interface{} {
-	if o == nil || o.JsonArgs == nil {
-		var ret map[string]interface{}
+// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CreateEdgeFunctionRequest) GetJsonArgs() interface{} {
+	if o == nil  {
+		var ret interface{}
 		return ret
 	}
-	return *o.JsonArgs
+	return o.JsonArgs
 }
 
 // GetJsonArgsOk returns a tuple with the JsonArgs field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *CreateEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CreateEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool) {
 	if o == nil || o.JsonArgs == nil {
 		return nil, false
 	}
-	return o.JsonArgs, true
+	return &o.JsonArgs, true
 }
 
 // HasJsonArgs returns a boolean if a field has been set.
@@ -164,9 +165,9 @@ func (o *CreateEdgeFunctionRequest) HasJsonArgs() bool {
 	return false
 }
 
-// SetJsonArgs gets a reference to the given map[string]interface{} and assigns it to the JsonArgs field.
-func (o *CreateEdgeFunctionRequest) SetJsonArgs(v map[string]interface{}) {
-	o.JsonArgs = &v
+// SetJsonArgs gets a reference to the given interface{} and assigns it to the JsonArgs field.
+func (o *CreateEdgeFunctionRequest) SetJsonArgs(v interface{}) {
+	o.JsonArgs = v
 }
 
 // GetActive returns the Active field value if set, zero value otherwise.

--- a/edgefunctions/model_patch_edge_function_request.go
+++ b/edgefunctions/model_patch_edge_function_request.go
@@ -18,7 +18,7 @@ import (
 type PatchEdgeFunctionRequest struct {
 	Name *string `json:"name,omitempty"`
 	Code *string `json:"code,omitempty"`
-	JsonArgs *map[string]interface{} `json:"json_args,omitempty"`
+	JsonArgs interface{} `json:"json_args,omitempty"`
 	Active *bool `json:"active,omitempty"`
 }
 
@@ -103,22 +103,23 @@ func (o *PatchEdgeFunctionRequest) SetCode(v string) {
 	o.Code = &v
 }
 
-// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise.
-func (o *PatchEdgeFunctionRequest) GetJsonArgs() map[string]interface{} {
-	if o == nil || o.JsonArgs == nil {
-		var ret map[string]interface{}
+// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *PatchEdgeFunctionRequest) GetJsonArgs() interface{} {
+	if o == nil  {
+		var ret interface{}
 		return ret
 	}
-	return *o.JsonArgs
+	return o.JsonArgs
 }
 
 // GetJsonArgsOk returns a tuple with the JsonArgs field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PatchEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *PatchEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool) {
 	if o == nil || o.JsonArgs == nil {
 		return nil, false
 	}
-	return o.JsonArgs, true
+	return &o.JsonArgs, true
 }
 
 // HasJsonArgs returns a boolean if a field has been set.
@@ -130,9 +131,9 @@ func (o *PatchEdgeFunctionRequest) HasJsonArgs() bool {
 	return false
 }
 
-// SetJsonArgs gets a reference to the given map[string]interface{} and assigns it to the JsonArgs field.
-func (o *PatchEdgeFunctionRequest) SetJsonArgs(v map[string]interface{}) {
-	o.JsonArgs = &v
+// SetJsonArgs gets a reference to the given interface{} and assigns it to the JsonArgs field.
+func (o *PatchEdgeFunctionRequest) SetJsonArgs(v interface{}) {
+	o.JsonArgs = v
 }
 
 // GetActive returns the Active field value if set, zero value otherwise.

--- a/edgefunctions/model_put_edge_function_request.go
+++ b/edgefunctions/model_put_edge_function_request.go
@@ -18,7 +18,7 @@ import (
 type PutEdgeFunctionRequest struct {
 	Name *string `json:"name,omitempty"`
 	Code *string `json:"code,omitempty"`
-	JsonArgs *map[string]interface{} `json:"json_args,omitempty"`
+	JsonArgs interface{} `json:"json_args,omitempty"`
 	Active *bool `json:"active,omitempty"`
 	InitiatorType *string `json:"initiator_type,omitempty"`
 	Language *string `json:"language,omitempty"`
@@ -105,22 +105,23 @@ func (o *PutEdgeFunctionRequest) SetCode(v string) {
 	o.Code = &v
 }
 
-// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise.
-func (o *PutEdgeFunctionRequest) GetJsonArgs() map[string]interface{} {
-	if o == nil || o.JsonArgs == nil {
-		var ret map[string]interface{}
+// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *PutEdgeFunctionRequest) GetJsonArgs() interface{} {
+	if o == nil  {
+		var ret interface{}
 		return ret
 	}
-	return *o.JsonArgs
+	return o.JsonArgs
 }
 
 // GetJsonArgsOk returns a tuple with the JsonArgs field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PutEdgeFunctionRequest) GetJsonArgsOk() (*map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *PutEdgeFunctionRequest) GetJsonArgsOk() (*interface{}, bool) {
 	if o == nil || o.JsonArgs == nil {
 		return nil, false
 	}
-	return o.JsonArgs, true
+	return &o.JsonArgs, true
 }
 
 // HasJsonArgs returns a boolean if a field has been set.
@@ -132,9 +133,9 @@ func (o *PutEdgeFunctionRequest) HasJsonArgs() bool {
 	return false
 }
 
-// SetJsonArgs gets a reference to the given map[string]interface{} and assigns it to the JsonArgs field.
-func (o *PutEdgeFunctionRequest) SetJsonArgs(v map[string]interface{}) {
-	o.JsonArgs = &v
+// SetJsonArgs gets a reference to the given interface{} and assigns it to the JsonArgs field.
+func (o *PutEdgeFunctionRequest) SetJsonArgs(v interface{}) {
+	o.JsonArgs = v
 }
 
 // GetActive returns the Active field value if set, zero value otherwise.

--- a/edgefunctions/model_results.go
+++ b/edgefunctions/model_results.go
@@ -20,7 +20,7 @@ type Results struct {
 	Name *string `json:"name,omitempty"`
 	Language *string `json:"language,omitempty"`
 	Code *string `json:"code,omitempty"`
-	JsonArgs *map[string]interface{} `json:"json_args,omitempty"`
+	JsonArgs interface{} `json:"json_args,omitempty"`
 	FunctionToRun *string `json:"function_to_run,omitempty"`
 	InitiatorType *string `json:"initiator_type,omitempty"`
 	Active *bool `json:"active,omitempty"`
@@ -174,22 +174,23 @@ func (o *Results) SetCode(v string) {
 	o.Code = &v
 }
 
-// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise.
-func (o *Results) GetJsonArgs() map[string]interface{} {
-	if o == nil || o.JsonArgs == nil {
-		var ret map[string]interface{}
+// GetJsonArgs returns the JsonArgs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Results) GetJsonArgs() interface{} {
+	if o == nil  {
+		var ret interface{}
 		return ret
 	}
-	return *o.JsonArgs
+	return o.JsonArgs
 }
 
 // GetJsonArgsOk returns a tuple with the JsonArgs field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Results) GetJsonArgsOk() (*map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *Results) GetJsonArgsOk() (*interface{}, bool) {
 	if o == nil || o.JsonArgs == nil {
 		return nil, false
 	}
-	return o.JsonArgs, true
+	return &o.JsonArgs, true
 }
 
 // HasJsonArgs returns a boolean if a field has been set.
@@ -201,9 +202,9 @@ func (o *Results) HasJsonArgs() bool {
 	return false
 }
 
-// SetJsonArgs gets a reference to the given map[string]interface{} and assigns it to the JsonArgs field.
-func (o *Results) SetJsonArgs(v map[string]interface{}) {
-	o.JsonArgs = &v
+// SetJsonArgs gets a reference to the given interface{} and assigns it to the JsonArgs field.
+func (o *Results) SetJsonArgs(v interface{}) {
+	o.JsonArgs = v
 }
 
 // GetFunctionToRun returns the FunctionToRun field value if set, zero value otherwise.


### PR DESCRIPTION
**WHAT**
We had a problem unmarshalling the `json_args` item, because we were not expecting to receive arrays. Now, `json_args` is changed into an empty interface, so it can receive any type.

**WHY**
[ENG-19324]

[ENG-19324]: https://aziontech.atlassian.net/browse/ENG-19324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ