### PR TITLE
chore: add patch fields to application SDK

### DIFF
--- a/edgeapplications/api/openapi.yaml
+++ b/edgeapplications/api/openapi.yaml
@@ -3030,6 +3030,10 @@ components:
           type: integer
         cdn_cache_settings:
           type: string
+        adaptive_delivery_action:
+          type: string
+        enable_caching_for_options:
+          type: boolean
         cdn_cache_settings_maximum_ttl:
           format: int64
           type: integer
@@ -3157,6 +3161,8 @@ components:
             type: string
           type: array
         enable_caching_for_post:
+          type: boolean
+        enable_caching_for_options:
           type: boolean
         l2_caching_enabled:
           type: boolean

--- a/edgeapplications/docs/ApplicationCachePatchRequest.md
+++ b/edgeapplications/docs/ApplicationCachePatchRequest.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **BrowserCacheSettings** | Pointer to **string** |  | [optional] 
 **BrowserCacheSettingsMaximumTtl** | Pointer to **int64** |  | [optional] 
 **CdnCacheSettings** | Pointer to **string** |  | [optional] 
+**AdaptiveDeliveryAction** | Pointer to **string** |  | [optional] 
+**EnableCachingForOptions** | Pointer to **bool** |  | [optional] 
 **CdnCacheSettingsMaximumTtl** | Pointer to **int64** |  | [optional] 
 **CacheByQueryString** | Pointer to **string** |  | [optional] 
 **QueryStringFields** | Pointer to **[]string** |  | [optional] 
@@ -139,6 +141,56 @@ SetCdnCacheSettings sets CdnCacheSettings field to given value.
 `func (o *ApplicationCachePatchRequest) HasCdnCacheSettings() bool`
 
 HasCdnCacheSettings returns a boolean if a field has been set.
+
+### GetAdaptiveDeliveryAction
+
+`func (o *ApplicationCachePatchRequest) GetAdaptiveDeliveryAction() string`
+
+GetAdaptiveDeliveryAction returns the AdaptiveDeliveryAction field if non-nil, zero value otherwise.
+
+### GetAdaptiveDeliveryActionOk
+
+`func (o *ApplicationCachePatchRequest) GetAdaptiveDeliveryActionOk() (*string, bool)`
+
+GetAdaptiveDeliveryActionOk returns a tuple with the AdaptiveDeliveryAction field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAdaptiveDeliveryAction
+
+`func (o *ApplicationCachePatchRequest) SetAdaptiveDeliveryAction(v string)`
+
+SetAdaptiveDeliveryAction sets AdaptiveDeliveryAction field to given value.
+
+### HasAdaptiveDeliveryAction
+
+`func (o *ApplicationCachePatchRequest) HasAdaptiveDeliveryAction() bool`
+
+HasAdaptiveDeliveryAction returns a boolean if a field has been set.
+
+### GetEnableCachingForOptions
+
+`func (o *ApplicationCachePatchRequest) GetEnableCachingForOptions() bool`
+
+GetEnableCachingForOptions returns the EnableCachingForOptions field if non-nil, zero value otherwise.
+
+### GetEnableCachingForOptionsOk
+
+`func (o *ApplicationCachePatchRequest) GetEnableCachingForOptionsOk() (*bool, bool)`
+
+GetEnableCachingForOptionsOk returns a tuple with the EnableCachingForOptions field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEnableCachingForOptions
+
+`func (o *ApplicationCachePatchRequest) SetEnableCachingForOptions(v bool)`
+
+SetEnableCachingForOptions sets EnableCachingForOptions field to given value.
+
+### HasEnableCachingForOptions
+
+`func (o *ApplicationCachePatchRequest) HasEnableCachingForOptions() bool`
+
+HasEnableCachingForOptions returns a boolean if a field has been set.
 
 ### GetCdnCacheSettingsMaximumTtl
 

--- a/edgeapplications/docs/ApplicationCacheResponseDetails.md
+++ b/edgeapplications/docs/ApplicationCacheResponseDetails.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **AdaptiveDeliveryAction** | Pointer to **string** |  | [optional] 
 **DeviceGroup** | Pointer to **[]string** |  | [optional] 
 **EnableCachingForPost** | **bool** |  | 
+**EnableCachingForOptions** | Pointer to **bool** |  | [optional] 
 **L2CachingEnabled** | **bool** |  | 
 
 ## Methods
@@ -348,6 +349,31 @@ and a boolean to check if the value has been set.
 
 SetEnableCachingForPost sets EnableCachingForPost field to given value.
 
+
+### GetEnableCachingForOptions
+
+`func (o *ApplicationCacheResponseDetails) GetEnableCachingForOptions() bool`
+
+GetEnableCachingForOptions returns the EnableCachingForOptions field if non-nil, zero value otherwise.
+
+### GetEnableCachingForOptionsOk
+
+`func (o *ApplicationCacheResponseDetails) GetEnableCachingForOptionsOk() (*bool, bool)`
+
+GetEnableCachingForOptionsOk returns a tuple with the EnableCachingForOptions field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEnableCachingForOptions
+
+`func (o *ApplicationCacheResponseDetails) SetEnableCachingForOptions(v bool)`
+
+SetEnableCachingForOptions sets EnableCachingForOptions field to given value.
+
+### HasEnableCachingForOptions
+
+`func (o *ApplicationCacheResponseDetails) HasEnableCachingForOptions() bool`
+
+HasEnableCachingForOptions returns a boolean if a field has been set.
 
 ### GetL2CachingEnabled
 

--- a/edgeapplications/model_application_cache_patch_request.go
+++ b/edgeapplications/model_application_cache_patch_request.go
@@ -23,6 +23,8 @@ type ApplicationCachePatchRequest struct {
 	BrowserCacheSettings *string `json:"browser_cache_settings,omitempty"`
 	BrowserCacheSettingsMaximumTtl *int64 `json:"browser_cache_settings_maximum_ttl,omitempty"`
 	CdnCacheSettings *string `json:"cdn_cache_settings,omitempty"`
+	AdaptiveDeliveryAction *string `json:"adaptive_delivery_action,omitempty"`
+	EnableCachingForOptions *bool `json:"enable_caching_for_options,omitempty"`
 	CdnCacheSettingsMaximumTtl *int64 `json:"cdn_cache_settings_maximum_ttl,omitempty"`
 	CacheByQueryString *string `json:"cache_by_query_string,omitempty"`
 	QueryStringFields []string `json:"query_string_fields,omitempty"`
@@ -180,6 +182,70 @@ func (o *ApplicationCachePatchRequest) HasCdnCacheSettings() bool {
 // SetCdnCacheSettings gets a reference to the given string and assigns it to the CdnCacheSettings field.
 func (o *ApplicationCachePatchRequest) SetCdnCacheSettings(v string) {
 	o.CdnCacheSettings = &v
+}
+
+// GetAdaptiveDeliveryAction returns the AdaptiveDeliveryAction field value if set, zero value otherwise.
+func (o *ApplicationCachePatchRequest) GetAdaptiveDeliveryAction() string {
+	if o == nil || isNil(o.AdaptiveDeliveryAction) {
+		var ret string
+		return ret
+	}
+	return *o.AdaptiveDeliveryAction
+}
+
+// GetAdaptiveDeliveryActionOk returns a tuple with the AdaptiveDeliveryAction field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ApplicationCachePatchRequest) GetAdaptiveDeliveryActionOk() (*string, bool) {
+	if o == nil || isNil(o.AdaptiveDeliveryAction) {
+		return nil, false
+	}
+	return o.AdaptiveDeliveryAction, true
+}
+
+// HasAdaptiveDeliveryAction returns a boolean if a field has been set.
+func (o *ApplicationCachePatchRequest) HasAdaptiveDeliveryAction() bool {
+	if o != nil && !isNil(o.AdaptiveDeliveryAction) {
+		return true
+	}
+
+	return false
+}
+
+// SetAdaptiveDeliveryAction gets a reference to the given string and assigns it to the AdaptiveDeliveryAction field.
+func (o *ApplicationCachePatchRequest) SetAdaptiveDeliveryAction(v string) {
+	o.AdaptiveDeliveryAction = &v
+}
+
+// GetEnableCachingForOptions returns the EnableCachingForOptions field value if set, zero value otherwise.
+func (o *ApplicationCachePatchRequest) GetEnableCachingForOptions() bool {
+	if o == nil || isNil(o.EnableCachingForOptions) {
+		var ret bool
+		return ret
+	}
+	return *o.EnableCachingForOptions
+}
+
+// GetEnableCachingForOptionsOk returns a tuple with the EnableCachingForOptions field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ApplicationCachePatchRequest) GetEnableCachingForOptionsOk() (*bool, bool) {
+	if o == nil || isNil(o.EnableCachingForOptions) {
+		return nil, false
+	}
+	return o.EnableCachingForOptions, true
+}
+
+// HasEnableCachingForOptions returns a boolean if a field has been set.
+func (o *ApplicationCachePatchRequest) HasEnableCachingForOptions() bool {
+	if o != nil && !isNil(o.EnableCachingForOptions) {
+		return true
+	}
+
+	return false
+}
+
+// SetEnableCachingForOptions gets a reference to the given bool and assigns it to the EnableCachingForOptions field.
+func (o *ApplicationCachePatchRequest) SetEnableCachingForOptions(v bool) {
+	o.EnableCachingForOptions = &v
 }
 
 // GetCdnCacheSettingsMaximumTtl returns the CdnCacheSettingsMaximumTtl field value if set, zero value otherwise.
@@ -587,6 +653,12 @@ func (o ApplicationCachePatchRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !isNil(o.CdnCacheSettings) {
 		toSerialize["cdn_cache_settings"] = o.CdnCacheSettings
+	}
+	if !isNil(o.AdaptiveDeliveryAction) {
+		toSerialize["adaptive_delivery_action"] = o.AdaptiveDeliveryAction
+	}
+	if !isNil(o.EnableCachingForOptions) {
+		toSerialize["enable_caching_for_options"] = o.EnableCachingForOptions
 	}
 	if !isNil(o.CdnCacheSettingsMaximumTtl) {
 		toSerialize["cdn_cache_settings_maximum_ttl"] = o.CdnCacheSettingsMaximumTtl

--- a/edgeapplications/model_application_cache_response_details.go
+++ b/edgeapplications/model_application_cache_response_details.go
@@ -33,6 +33,7 @@ type ApplicationCacheResponseDetails struct {
 	AdaptiveDeliveryAction *string `json:"adaptive_delivery_action,omitempty"`
 	DeviceGroup []string `json:"device_group,omitempty"`
 	EnableCachingForPost bool `json:"enable_caching_for_post"`
+	EnableCachingForOptions *bool `json:"enable_caching_for_options,omitempty"`
 	L2CachingEnabled bool `json:"l2_caching_enabled"`
 }
 
@@ -422,6 +423,38 @@ func (o *ApplicationCacheResponseDetails) SetEnableCachingForPost(v bool) {
 	o.EnableCachingForPost = v
 }
 
+// GetEnableCachingForOptions returns the EnableCachingForOptions field value if set, zero value otherwise.
+func (o *ApplicationCacheResponseDetails) GetEnableCachingForOptions() bool {
+	if o == nil || isNil(o.EnableCachingForOptions) {
+		var ret bool
+		return ret
+	}
+	return *o.EnableCachingForOptions
+}
+
+// GetEnableCachingForOptionsOk returns a tuple with the EnableCachingForOptions field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ApplicationCacheResponseDetails) GetEnableCachingForOptionsOk() (*bool, bool) {
+	if o == nil || isNil(o.EnableCachingForOptions) {
+		return nil, false
+	}
+	return o.EnableCachingForOptions, true
+}
+
+// HasEnableCachingForOptions returns a boolean if a field has been set.
+func (o *ApplicationCacheResponseDetails) HasEnableCachingForOptions() bool {
+	if o != nil && !isNil(o.EnableCachingForOptions) {
+		return true
+	}
+
+	return false
+}
+
+// SetEnableCachingForOptions gets a reference to the given bool and assigns it to the EnableCachingForOptions field.
+func (o *ApplicationCacheResponseDetails) SetEnableCachingForOptions(v bool) {
+	o.EnableCachingForOptions = &v
+}
+
 // GetL2CachingEnabled returns the L2CachingEnabled field value
 func (o *ApplicationCacheResponseDetails) GetL2CachingEnabled() bool {
 	if o == nil {
@@ -478,6 +511,9 @@ func (o ApplicationCacheResponseDetails) ToMap() (map[string]interface{}, error)
 		toSerialize["device_group"] = o.DeviceGroup
 	}
 	toSerialize["enable_caching_for_post"] = o.EnableCachingForPost
+	if !isNil(o.EnableCachingForOptions) {
+		toSerialize["enable_caching_for_options"] = o.EnableCachingForOptions
+	}
 	toSerialize["l2_caching_enabled"] = o.L2CachingEnabled
 	return toSerialize, nil
 }


### PR DESCRIPTION
**WHAT**
- Patch endpoint for cache_settings was missing two fields.